### PR TITLE
rework lumber redistribute behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 NEXT
 [LIST]
 [*] The lumber redistribute now activates at 25 wood, up from 20.
+[*] Re-worked the lumber redistribute event to occur instantly, which should improve predictability.
 [/LIST]
 
 0.20q

--- a/wurst/Creeps/bosses/Boss.wurst
+++ b/wurst/Creeps/bosses/Boss.wurst
@@ -1,22 +1,23 @@
 package Boss
 import public Creep
+import LumberAndCoinSystem
 import public SoundUtils
 import public PhysicsProjectile
 
 public abstract class Boss extends Creep
 	static constant snd = new SoundDefinition(Sounds.abominationAlternateDeath1, false)
 	effect glow
-	
+
 	construct(vec3 pos, int typId, int bounty, vec2 target)
 		super(pos, typId, bounty, target, pos.angleTo2d(target))
 		glow = actor.addEffect("war3mapImported\\GeneralHeroGlow.mdx", "origin")
 		if typId == 'n003'
 			snd.play()
-			
+
 
 	override function onDeath()
-		for p in allPlayers
-			p.p.addLumber(1)
+		allPlayers.addLumber(1, true)
+
 		if glow != null
 			glow.destr()
 		super.onDeath()

--- a/wurst/systems/LumberAndCoinSystem.wurst
+++ b/wurst/systems/LumberAndCoinSystem.wurst
@@ -1,6 +1,7 @@
 package LumberAndCoinSystem
 import Creep
 import Assets
+import GameTimer
 
 constant WOOD_REDISTRIBUTE_THRESHOLD = 25
 
@@ -15,17 +16,26 @@ var coinCount = GetRandomInt(-2, 3)
 var coinCap = 16
 var coinsSpawned = 0
 
+constant WOOD_REDISTRIBUTE_MIN_WAIT = 60.
+var lastRedistribute = 0.
+
 /**
 	Add `amt` lumber to each player's pool.  If `redistribute`, players with too
-	much lumber will be forced to share.
+	much lumber will be forced to share.  This is gated on having waited at
+	east `WOOD_REDISTRIBUTE_MIN_WAIT` seconds since the last redistribute event.
 */
 public function LinkedList<PlayerData>.addLumber(int amt, bool redistribute)
 	for pd in this
 		pd.p.addLumber(amt)
 
-	if redistribute and this.size() > 1
+	if (
+		redistribute and
+		this.size() > 1 and
+		getElapsedGameTime() > (lastRedistribute + WOOD_REDISTRIBUTE_MIN_WAIT)
+	)
 		for pd in this
 			if pd.p.getLumber() > WOOD_REDISTRIBUTE_THRESHOLD
+				lastRedistribute = getElapsedGameTime()
 				let val = (pd.p.getLumber() / allPlayers.size()).toInt()
 				let remainder = pd.p.getLumber() mod allPlayers.size()
 				pd.p.setLumber(remainder)
@@ -33,8 +43,7 @@ public function LinkedList<PlayerData>.addLumber(int amt, bool redistribute)
 				printTimedToPlayer(
 					"Due to inactivity, your lumber has been dispersed amongst your teammates!",
 					10.,
-					pd.p
-				)
+					pd.p)
 
 
 public function shouldSpawnCoin() returns boolean

--- a/wurst/systems/LumberAndCoinSystem.wurst
+++ b/wurst/systems/LumberAndCoinSystem.wurst
@@ -15,6 +15,28 @@ var coinCount = GetRandomInt(-2, 3)
 var coinCap = 16
 var coinsSpawned = 0
 
+/**
+	Add `amt` lumber to each player's pool.  If `redistribute`, players with too
+	much lumber will be forced to share.
+*/
+public function LinkedList<PlayerData>.addLumber(int amt, bool redistribute)
+	for pd in this
+		pd.p.addLumber(amt)
+
+	if redistribute and this.size() > 1
+		for pd in this
+			if pd.p.getLumber() > WOOD_REDISTRIBUTE_THRESHOLD
+				let val = (pd.p.getLumber() / allPlayers.size()).toInt()
+				let remainder = pd.p.getLumber() mod allPlayers.size()
+				pd.p.setLumber(remainder)
+				allPlayers.addLumber(val, false)
+				printTimedToPlayer(
+					"Due to inactivity, your lumber has been dispersed amongst your teammates!",
+					10.,
+					pd.p
+				)
+
+
 public function shouldSpawnCoin() returns boolean
 	coinCount++
 	if coinCount >= coinCap
@@ -26,6 +48,7 @@ public function shouldSpawnCoin() returns boolean
 		coinsSpawned++
 		return true
 	return false
+
 
 function getExtraBounty()
 	let victim = GetDyingUnit().getOwner()
@@ -46,14 +69,6 @@ function getExtraBounty()
 				if itm != null and itm.getLife() > .405
 					itm.remove()
 
-			for pd in allPlayers
-				if pd.p.getLumber() > WOOD_REDISTRIBUTE_THRESHOLD and allPlayers.size() > 1
- 					let val = (pd.p.getLumber() / allPlayers.size()).toInt()
-					let remainder = pd.p.getLumber() mod allPlayers.size()
-					pd.p.setLumber(remainder)
-					for p2 in allPlayers
-						p2.p.addLumber(val)
-					printTimedToPlayer("Due to inactivity your lumber has been dispersed among teammates!", 10, pd.p)
 
 function grantCoinsAndLumber()
 	let itm = GetManipulatedItem()
@@ -72,20 +87,14 @@ function grantCoinsAndLumber()
 	if itm.getTypeId() == WOOD_ID
 		flashEffect(Objects.entBirthTarget, GetManipulatingUnit().getPos())
 		printTimed("|cffFFCC00>> " + GetManipulatingUnit().getOwner().getNameColored() + " picked up a lumber bundle!", 10.)
+		allPlayers.addLumber(WOOD_BOUNTY, true)
+
 		for pd in allPlayers
-			pd.p.addLumber(WOOD_BOUNTY)
 			if pd.builder.actor != null and pd.builder.actor.isAlive()
 				createFText(pd.builder.getPos() - vec2(16,0), "+" + WOOD_BOUNTY.toString(), 0.024 / 0.0023)
 					..setDynamic(vec2(0., .03), 3.)
 					.tt..setFadepoint(2.)
 						..setColor(0, 200, 80, 255)
-			if pd.p.getLumber() > 20 and allPlayers.size() > 1
-				let val = (pd.p.getLumber() / allPlayers.size()).toInt()
-				let remainder = pd.p.getLumber() mod allPlayers.size()
-				pd.p.setLumber(remainder)
-				for p2 in allPlayers
-					p2.p.addLumber(val)
-				printTimedToPlayer("Due to inactivity your lumber has been dispersed among teammates!", 10, pd.p)
 
 
 public function initLumberSystem()

--- a/wurst/systems/LumberAndCoinSystem.wurst
+++ b/wurst/systems/LumberAndCoinSystem.wurst
@@ -28,11 +28,10 @@ public function LinkedList<PlayerData>.addLumber(int amt, bool redistribute)
 	for pd in this
 		pd.p.addLumber(amt)
 
-	if (
-		redistribute and
+	if (redistribute and
 		this.size() > 1 and
-		getElapsedGameTime() > (lastRedistribute + WOOD_REDISTRIBUTE_MIN_WAIT)
-	)
+		getElapsedGameTime() > (lastRedistribute + WOOD_REDISTRIBUTE_MIN_WAIT))
+
 		for pd in this
 			if pd.p.getLumber() > WOOD_REDISTRIBUTE_THRESHOLD
 				lastRedistribute = getElapsedGameTime()


### PR DESCRIPTION
Concerns (please read):

- It is now possible for this event to be quite spammy, if none of the players spend their lumber
- I've not tested this for correctness
- This will only work nicely if we commit to using `LinkedList<>.addLumber(int, bool)` in the general case